### PR TITLE
OrderBook sorting & other fixes

### DIFF
--- a/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/BitcoindeAdapters.java
+++ b/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/BitcoindeAdapters.java
@@ -56,7 +56,7 @@ public final class BitcoindeAdapters {
 
     List<LimitOrder> limitOrders = new ArrayList<LimitOrder>();
     for (BigDecimal[] order : orders) {
-      limitOrders.add(createOrder(currencyPair, order, orderType));
+      limitOrders.add(createOrder(currencyPair, order, orderType, null, null));
     }
     return limitOrders;
   }
@@ -64,9 +64,9 @@ public final class BitcoindeAdapters {
   /**
    * Create an individual order.
    */
-  public static LimitOrder createOrder(CurrencyPair currencyPair, BigDecimal[] priceAndAmount, Order.OrderType orderType) {
-
-    return new LimitOrder(orderType, priceAndAmount[1], currencyPair, null, null, priceAndAmount[0]);
+  public static LimitOrder createOrder(CurrencyPair currencyPair, BigDecimal[] priceAndAmount, Order.OrderType orderType, String orderId, Date timeStamp) {
+    
+    return new LimitOrder(orderType, priceAndAmount[1], currencyPair, orderId, timeStamp, priceAndAmount[0]);
   }
 
   /**

--- a/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/BitcoindeAdapters.java
+++ b/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/BitcoindeAdapters.java
@@ -66,7 +66,7 @@ public final class BitcoindeAdapters {
    */
   public static LimitOrder createOrder(CurrencyPair currencyPair, BigDecimal[] priceAndAmount, Order.OrderType orderType) {
 
-    return new LimitOrder(orderType, priceAndAmount[1], currencyPair, "", null, priceAndAmount[0]);
+    return new LimitOrder(orderType, priceAndAmount[1], currencyPair, null, null, priceAndAmount[0]);
   }
 
   /**

--- a/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/BitcoindeAdapters.java
+++ b/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/BitcoindeAdapters.java
@@ -46,7 +46,7 @@ public final class BitcoindeAdapters {
 
     List<LimitOrder> asks = createOrders(currencyPair, Order.OrderType.ASK, bitcoindeOrderBook.getAsks());
     List<LimitOrder> bids = createOrders(currencyPair, Order.OrderType.BID, bitcoindeOrderBook.getBids());
-    return new OrderBook(null, asks, bids);
+    return new OrderBook(bitcoindeOrderBook.getTimeStamp(), asks, bids);
   }
 
   /**

--- a/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeOrderBook.java
+++ b/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeOrderBook.java
@@ -2,6 +2,8 @@ package com.xeiam.xchange.bitcoinde.dto.marketdata;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Comparator;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -20,8 +22,30 @@ public class BitcoindeOrderBook {
    */
   public BitcoindeOrderBook(@JsonProperty("asks") BigDecimal[][] asks, @JsonProperty("bids") BigDecimal[][] bids) {
 
+    /* set the asks and bids */
     this.asks = asks;
     this.bids = bids;
+    
+    /* sort the asks in ascending order by price */
+    Arrays.sort(this.asks, new Comparator<BigDecimal[]>() {
+      @Override
+      public int compare(final BigDecimal[] entry1, final BigDecimal[] entry2) {
+        final BigDecimal price1 = entry1[0]; // the first element of entry
+        final BigDecimal price2 = entry2[0]; // is the price in EUR
+
+        return price1.compareTo(price2);
+      }
+    });
+    
+    /* sort the bids in descending order by price */
+    Arrays.sort(this.bids, new Comparator<BigDecimal[]>() {
+     @Override
+     public int compare(final BigDecimal[] entry1, final BigDecimal[] entry2) {
+       final BigDecimal price1 = entry1[0]; // the first elements of entry
+       final BigDecimal price2 = entry2[0]; // is price in EUR
+       return -1 * price1.compareTo(price2); // multiply by -1 to reverse the order (we want descending)
+     }
+    });
   }
 
   public BigDecimal[][] getAsks() {

--- a/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeOrderBook.java
+++ b/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeOrderBook.java
@@ -3,6 +3,7 @@ package com.xeiam.xchange.bitcoinde.dto.marketdata;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -13,6 +14,7 @@ public class BitcoindeOrderBook {
 
   private final BigDecimal[][] asks;
   private final BigDecimal[][] bids;
+  private final Date timeStamp = null;
 
   /**
    * Constructor.
@@ -56,6 +58,10 @@ public class BitcoindeOrderBook {
   public BigDecimal[][] getBids() {
 
     return bids;
+  }
+  
+  public Date getTimeStamp() {
+    return this.timeStamp;
   }
 
   @Override

--- a/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/service/polling/BitcoindeMarketDataService.java
+++ b/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/service/polling/BitcoindeMarketDataService.java
@@ -8,6 +8,7 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
 import com.xeiam.xchange.dto.marketdata.Trades;
+import com.xeiam.xchange.exceptions.NotAvailableFromExchangeException;
 import com.xeiam.xchange.service.polling.marketdata.PollingMarketDataService;
 
 /**
@@ -28,7 +29,7 @@ public class BitcoindeMarketDataService extends BitcoindeMarketDataServiceRaw im
   @Override
   public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws IOException {
 
-    return BitcoindeAdapters.adaptTicker(getBitcoindeRate(), currencyPair);
+    throw new NotAvailableFromExchangeException();
   }
 
   @Override

--- a/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/service/polling/BitcoindeMarketDataServiceRaw.java
+++ b/xchange-bitcoinde/src/main/java/com/xeiam/xchange/bitcoinde/service/polling/BitcoindeMarketDataServiceRaw.java
@@ -30,8 +30,6 @@ public class BitcoindeMarketDataServiceRaw extends BitcoindeBasePollingService {
 
   public BitcoindeRate getBitcoindeRate() throws IOException {
 
-    if (bitcoinde == null)
-      System.out.println("You're null!");
     return bitcoinde.getRate();
   }
 

--- a/xchange-bitcoinde/src/main/resources/bitcoinde.json
+++ b/xchange-bitcoinde/src/main/resources/bitcoinde.json
@@ -2,6 +2,6 @@
 	"currency_pairs":[
 		"BTC/EUR"
 	],
-	"max_private_poll_rate_per_minute":60
+	"max_private_poll_rate_per_minute":2
          
 }

--- a/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/BitcoindeAdapterTest.java
+++ b/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/BitcoindeAdapterTest.java
@@ -36,10 +36,12 @@ public class BitcoindeAdapterTest {
     // Create a generic OrderBook object from a Bitcoinde specific OrderBook
     OrderBook orderBook = BitcoindeAdapters.adaptOrderBook(bitcoindeOrderBook, CurrencyPair.BTC_EUR);
 
+System.out.println(orderBook.getBids().get(0).getLimitPrice().toString());
+System.out.println(orderBook.getBids().get(0).getTradableAmount());
     // verify all fields are filled correctly
-    assertThat(orderBook.getBids().get(0).getLimitPrice().toString()).isEqualTo("200");
+    assertThat(orderBook.getBids().get(0).getLimitPrice().toString()).isEqualTo("222.5");
     assertThat(orderBook.getBids().get(0).getType()).isEqualTo(OrderType.BID);
-    assertThat(orderBook.getBids().get(0).getTradableAmount()).isEqualTo(new BigDecimal("10"));
+    assertThat(orderBook.getBids().get(0).getTradableAmount()).isEqualTo(new BigDecimal("0.35"));
     assertThat(orderBook.getBids().get(0).getCurrencyPair()).isEqualTo(CurrencyPair.BTC_EUR);
   }
 

--- a/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/BitcoindeAdapterTest.java
+++ b/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/BitcoindeAdapterTest.java
@@ -36,8 +36,6 @@ public class BitcoindeAdapterTest {
     // Create a generic OrderBook object from a Bitcoinde specific OrderBook
     OrderBook orderBook = BitcoindeAdapters.adaptOrderBook(bitcoindeOrderBook, CurrencyPair.BTC_EUR);
 
-System.out.println(orderBook.getBids().get(0).getLimitPrice().toString());
-System.out.println(orderBook.getBids().get(0).getTradableAmount());
     // verify all fields are filled correctly
     assertThat(orderBook.getBids().get(0).getLimitPrice().toString()).isEqualTo("222.5");
     assertThat(orderBook.getBids().get(0).getType()).isEqualTo(OrderType.BID);

--- a/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeOrderBookIntegration.java
+++ b/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeOrderBookIntegration.java
@@ -9,13 +9,13 @@ import com.xeiam.xchange.ExchangeFactory;
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.bitcoinde.BitcoindeExchange;
 import com.xeiam.xchange.currency.CurrencyPair;
-import com.xeiam.xchange.dto.marketdata.Ticker;
+import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.service.polling.marketdata.PollingMarketDataService;
 
-public class BitcoindeTickerIntegration {
+public class BitcoindeOrderBookIntegration {
 
   @Test
-  public void bitcoindeTickerTest() throws IOException {
+  public void bitcoindeOrderBookTest() throws IOException {
 
     /*
      * Get the API key from an environmental variable,
@@ -38,9 +38,9 @@ public class BitcoindeTickerIntegration {
     /* create a data service from the exchange */
     PollingMarketDataService marketDataService = bitcoindeExchange.getPollingMarketDataService();
 
-    /* display our ticker data */
-    Ticker ticker = marketDataService.getTicker(CurrencyPair.BTC_EUR);
-    System.out.println(ticker.toString());
+    /* display the first ask of our OrderBook */
+    OrderBook orderBook = marketDataService.getOrderBook(CurrencyPair.BTC_EUR);
+    System.out.println(orderBook.getAsks().get(0));
   }
 
 }

--- a/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeOrderBookTest.java
+++ b/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeOrderBookTest.java
@@ -29,11 +29,11 @@ public class BitcoindeOrderBookTest {
     BitcoindeOrderBook bitcoindeOrderBook = mapper.readValue(is, BitcoindeOrderBook.class);
 
     // Make sure asks are correct
-    assertEquals(bitcoindeOrderBook.getAsks()[0][0], new BigDecimal("335"));
-    assertEquals(bitcoindeOrderBook.getAsks()[0][1], new BigDecimal("3.98"));
+    assertEquals(bitcoindeOrderBook.getAsks()[0][0], new BigDecimal("224.9"));
+    assertEquals(bitcoindeOrderBook.getAsks()[0][1], new BigDecimal("2.48889"));
 
     // Make sure bids are correct
-    assertEquals(bitcoindeOrderBook.getBids()[0][0], new BigDecimal("200"));
-    assertEquals(bitcoindeOrderBook.getBids()[0][1], new BigDecimal("10"));
+    assertEquals(bitcoindeOrderBook.getBids()[0][0], new BigDecimal("222.5"));
+    assertEquals(bitcoindeOrderBook.getBids()[0][1], new BigDecimal("0.35"));
   }
 }

--- a/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeTickerIntegration.java
+++ b/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeTickerIntegration.java
@@ -23,7 +23,7 @@ public class BitcoindeTickerIntegration {
      * to set this variable.
      */
     final String API_KEY = System.getenv("BITCOINDE_API_KEY");
-    if (API_KEY == null) { // if the environmental variable isn't set
+    if (API_KEY == null || API_KEY == "") { // if the environmental variable isn't set
 	    System.err.println("Error: please set the environmental variable BITCOINDE_API_KEY equal to your API key before running this integration test. Try $ export BITCOINDE_API_KEY=myapikey123");
 	    System.exit(1);
     }

--- a/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeTickerIntegration.java
+++ b/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeTickerIntegration.java
@@ -23,8 +23,10 @@ public class BitcoindeTickerIntegration {
      * to set this variable.
      */
     final String API_KEY = System.getenv("BITCOINDE_API_KEY");
-    if (API_KEY == null) // if the environmental variable isn't set
+    if (API_KEY == null) { // if the environmental variable isn't set
 	    System.err.println("Error: please set the environmental variable BITCOINDE_API_KEY equal to your API key before running this integration test. Try $ export BITCOINDE_API_KEY=myapikey123");
+	    System.exit(1);
+    }
 
     /* configure the exchange to use our api key */
     ExchangeSpecification exchangeSpecification = new ExchangeSpecification(BitcoindeExchange.class.getName());

--- a/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeTickerIntegration.java
+++ b/xchange-bitcoinde/src/test/java/com/xeiam/xchange/bitcoinde/dto/marketdata/BitcoindeTickerIntegration.java
@@ -23,6 +23,8 @@ public class BitcoindeTickerIntegration {
      * to set this variable.
      */
     final String API_KEY = System.getenv("BITCOINDE_API_KEY");
+    if (API_KEY == null) // if the environmental variable isn't set
+	    System.err.println("Error: please set the environmental variable BITCOINDE_API_KEY equal to your API key before running this integration test. Try $ export BITCOINDE_API_KEY=myapikey123");
 
     /* configure the exchange to use our api key */
     ExchangeSpecification exchangeSpecification = new ExchangeSpecification(BitcoindeExchange.class.getName());

--- a/xchange-bitstamp/src/main/resources/bitstamp.json
+++ b/xchange-bitstamp/src/main/resources/bitstamp.json
@@ -2,6 +2,6 @@
    "currency_pairs":[
       "BTC/USD"
    ],
-   "max_public_poll_rate_per_minute":2
+   "max_public_poll_rate_per_minute":60
    
 }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitcoinde/marketdata/BitcoindeOrderBookDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitcoinde/marketdata/BitcoindeOrderBookDemo.java
@@ -14,7 +14,7 @@ import com.xeiam.xchange.service.polling.marketdata.PollingMarketDataService;
 
 public class BitcoindeOrderBookDemo {
 
-  public void main(String[] args) throws IOException {
+  public static void main(String[] args) throws IOException {
 
     /* get the api key from args */
     if (args.length != 1) {
@@ -38,14 +38,14 @@ public class BitcoindeOrderBookDemo {
 
   }
 
-  public void generic(PollingMarketDataService marketDataService) throws IOException {
+  public static void generic(PollingMarketDataService marketDataService) throws IOException {
 
     /* get OrderBook data */
     OrderBook orderBook = marketDataService.getOrderBook(CurrencyPair.BTC_EUR);
     System.out.println(orderBook.toString());
   }
 
-  public void raw(BitcoindeMarketDataServiceRaw marketDataService) throws IOException {
+  public static void raw(BitcoindeMarketDataServiceRaw marketDataService) throws IOException {
 
     /* get BitcoindeOrderBook data */
     BitcoindeOrderBook bitcoindeOrderBook = marketDataService.getBitcoindeOrderBook();

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitcoinde/marketdata/BitcoindeTickerDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitcoinde/marketdata/BitcoindeTickerDemo.java
@@ -14,7 +14,7 @@ import com.xeiam.xchange.service.polling.marketdata.PollingMarketDataService;
 
 public class BitcoindeTickerDemo {
 
-  public void main(String[] args) throws IOException {
+  public static void main(String[] args) throws IOException {
 
     /* get the api key from args */
     if (args.length != 1) {
@@ -33,21 +33,17 @@ public class BitcoindeTickerDemo {
     /* create a data service from the exchange */
     PollingMarketDataService marketDataService = bitcoindeExchange.getPollingMarketDataService();
 
-    generic(marketDataService);
+    /* We can't get a real ticker since Bitcoin.de doesn't
+     * support it, but we can get an exchange rate. Use a 
+     * BitcoindeRate object for this.
+     */
     raw((BitcoindeMarketDataServiceRaw) marketDataService);
 
   }
 
-  public void generic(PollingMarketDataService marketDataService) throws IOException {
+  public static void raw(BitcoindeMarketDataServiceRaw marketDataService) throws IOException {
 
-    /* get Ticker data */
-    Ticker ticker = marketDataService.getTicker(CurrencyPair.BTC_EUR);
-    System.out.println(ticker.toString());
-  }
-
-  public void raw(BitcoindeMarketDataServiceRaw marketDataService) throws IOException {
-
-    /* get BitcoindeRate data (Bitcoinde does not provide a ticker, only and exchange rate) */
+    /* get BitcoindeRate data */
     BitcoindeRate bitcoindeRate = marketDataService.getBitcoindeRate();
     System.out.println(bitcoindeRate.toString());
   }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitcoinde/marketdata/BitcoindeTradesDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitcoinde/marketdata/BitcoindeTradesDemo.java
@@ -14,7 +14,7 @@ import com.xeiam.xchange.service.polling.marketdata.PollingMarketDataService;
 
 public class BitcoindeTradesDemo {
 
-  public void main(String[] args) throws IOException {
+  public static void main(String[] args) throws IOException {
 
     /* get the api key from args */
     if (args.length != 1) {
@@ -37,17 +37,20 @@ public class BitcoindeTradesDemo {
     raw((BitcoindeMarketDataServiceRaw) marketDataService);
   }
 
-  public void generic(PollingMarketDataService marketDataService) throws IOException {
+  public static void generic(PollingMarketDataService marketDataService) throws IOException {
 
     /* get Trades data */
     Trades trades = marketDataService.getTrades(CurrencyPair.BTC_EUR);
     System.out.println(trades.toString());
   }
 
-  public void raw(BitcoindeMarketDataServiceRaw marketDataService) throws IOException {
+  public static void raw(BitcoindeMarketDataServiceRaw marketDataService) throws IOException {
 
     /* get BitcoindeTrades data */
     BitcoindeTrade[] bitcoindeTrades = marketDataService.getBitcoindeTrades();
-    System.out.println(bitcoindeTrades);
+    
+    /* print each trade object */
+    for (BitcoindeTrade bitcoindeTrade : bitcoindeTrades)
+	    System.out.println(bitcoindeTrade);
   }
 }


### PR DESCRIPTION
This update addresses each of the following points from your email:
* need to use static modifiers on the examples. otherwise i can't run the examples as standalone mains.
* If a real ticker is not available from the exchange, throw NotAvailableFromExchangeException for generic interface methods, but show how you could get ticker-like data from raw interface.
* The max poll rate appears to be incorrect. You have 60. From their API docs: "Access to the API is limited to two calls every 60 seconds. Tradehistory and orderbook are updated every 60 seconds."
* this line "BitcoindeTrade[] bitcoindeTrades = marketDataService.getBitcoindeTrades(); System.out.println(bitcoindeTrades);" in the trades example doesn't work because you're trying to print an array, not the BitcoindeTrade in the array. Instead, loop over and print the BitcoindeTrade object itself.
* For orderbooks, I prefer putting in the value of null rather than the empty string when values (such as timestamp or id) are not provided by the exchange.)
* The orderbooks need to be sorted. asks are sorted in ascending order by price. bids are sorted in descending order by price....this is very very very important. Use Comparators to make this happen.